### PR TITLE
fix: package release assets as single zip file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,12 @@ jobs:
           -p:Version=${{ steps.version.outputs.VERSION }}
           -o ./publish
 
+      - name: Package release archive
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.VERSION }}"
+          Compress-Archive -Path publish/ZipDrive.exe, publish/appsettings.json -DestinationPath "ZipDrive-$version.zip"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -75,8 +81,7 @@ jobs:
             "release", "create", "v$version",
             "--title", "ZipDrive $version",
             "--generate-notes",
-            "publish/ZipDrive.exe",
-            "publish/appsettings.json"
+            "ZipDrive-$version.zip"
           )
           if ($prerelease -eq "true") {
             $args += "--prerelease"


### PR DESCRIPTION
## Summary

- Release workflow now produces a single `ZipDrive-{version}.zip` containing `ZipDrive.exe` + `appsettings.json` instead of attaching them as separate files

## Test plan

- [x] Release workflow creates zip archive as single asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)