### PR TITLE
feat(dokan): add shell metadata short-circuit and debug logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,12 @@ DokanNet integration for Windows file system mounting.
 - `DokanFileSystemAdapter`: Implements `IDokanOperations2`, translates Dokan calls to `IVirtualFileSystem`
 - `DokanHostedService`: `IHostedService` that manages mount/unmount lifecycle
 - `DokanTelemetry`: Static `Meter("ZipDrive.Dokan")` with read latency histogram
+- `ShellMetadataFilter`: Zero-allocation static helper that identifies Windows shell metadata paths (`desktop.ini`, `thumbs.db`, `$RECYCLE.BIN`, etc.) using `ReadOnlySpan<char>` matching
+- `MountOptions`: Configuration POCO with `ShortCircuitShellMetadata` toggle (default: `true`)
+
+**Shell Metadata Short-Circuit**: Windows Explorer probes every folder for metadata files like `desktop.ini`, `thumbs.db`, and `autorun.inf`. Without filtering, these probes trigger unnecessary ZIP Central Directory parsing. The `ShellMetadataFilter` intercepts these in `CreateFile` before any string allocation occurs, returning `FileNotFound` immediately. Controlled via `Mount:ShortCircuitShellMetadata` in `appsettings.json`.
+
+**Debug Logging**: All Dokan file system operations log at `Debug` level with the command name and file path, enabling detailed diagnostics when the Serilog minimum level is lowered.
 
 ### Presentation Layer (`src/ZipDrive.Cli`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ Run with:
 ZipDrive.exe --Mount:ArchiveDirectory="D:\my-zips" --Mount:MountPoint="R:\"
 ```
 
+**Versioning**: `Directory.Build.props` sets `<Version>1.0.0-dev</Version>` as the default. The startup log displays the version with the `+commit-hash` metadata stripped (e.g., `ZipDrive 1.0.0-dev starting`). For release builds, the CI pipeline overrides this via `-p:Version=1.0.0` on the `dotnet publish` command line (see `.github/workflows/release.yml`), producing `ZipDrive 1.0.0 starting`.
+
 **Single-file note**: Serilog cannot auto-discover sink assemblies in single-file mode. The CLI explicitly passes `ConfigurationReaderOptions` with the Console sink assembly. If adding new Serilog sinks, register their assemblies in `Program.cs`.
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,6 +459,22 @@ This solution uses **Central Package Management**. All package versions are defi
 5. Use `dotnet-counters monitor --counters ZipDrive.Caching` for quick CLI metrics
 6. Use deterministic tests with `FakeTimeProvider` to reproduce timing issues
 
+### Addressing GitHub Copilot PR Review Comments
+
+After creating a PR, GitHub Copilot may leave review comments. Follow this workflow:
+
+1. **Check comments**: `gh api repos/{owner}/{repo}/pulls/{pr}/comments` or use `pull_request_read` with `get_review_comments`
+2. **Analyze each comment**: Determine if the feedback is valid and actionable
+3. **Fix valid issues**: Make code changes, add tests, commit and push to the PR branch
+4. **Reply to each comment**: Use `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies -f body="..."` to explain what was done (or why a comment was declined)
+5. **Resolve conversations**: Query thread IDs via GraphQL, then resolve each with `resolveReviewThread` mutation:
+   ```bash
+   # Get thread IDs
+   gh api graphql -f query='{ repository(owner: "...", name: "...") { pullRequest(number: N) { reviewThreads(first: 20) { nodes { id isResolved } } } } }'
+   # Resolve a thread
+   gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'
+   ```
+
 ## Important Architectural Decisions
 
 ### Why NOT use built-in MemoryCache?

--- a/README.md
+++ b/README.md
@@ -30,23 +30,18 @@ This mounts all ZIP files found under `D:\my-zips` as the `R:\` drive.
 
 ### Building from Source
 
-```bash
+```powershell
 # Build
 dotnet build ZipDrive.slnx
 
 # Run
-dotnet run --project src/ZipDrive.Cli/ZipDrive.Cli.csproj -- \
-  --Mount:ArchiveDirectory="D:\my-zips" --Mount:MountPoint="R:\"
+dotnet run --project src/ZipDrive.Cli/ZipDrive.Cli.csproj -- --Mount:ArchiveDirectory="D:\my-zips" --Mount:MountPoint="R:\"
 ```
 
 ### Publishing a Single-File Executable
 
-```bash
-dotnet publish src/ZipDrive.Cli/ZipDrive.Cli.csproj \
-  -c Release -r win-x64 --self-contained false \
-  -p:PublishSingleFile=true \
-  -p:IncludeNativeLibrariesForSelfExtract=true \
-  -o ./publish
+```powershell
+dotnet publish src/ZipDrive.Cli/ZipDrive.Cli.csproj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o ./publish
 ```
 
 Output: `publish/ZipDrive.exe` (~74 MB) + `publish/appsettings.json`
@@ -61,8 +56,8 @@ ZipDrive.exe
 
 Command-line arguments **override** `appsettings.json` values using the `--Section:Key=Value` syntax:
 
-```bash
-ZipDrive.exe --Mount:ArchiveDirectory="D:\my-zips" --Mount:MountPoint="Z:\"
+```powershell
+ZipDrive.exe --Mount:ArchiveDirectory="D:\my-zips" --Mount:MountPoint="Z:\" --Cache:TempDirectory="D:\zipdrive-cache"
 ```
 
 ### Mount Options

--- a/README.md
+++ b/README.md
@@ -53,7 +53,17 @@ Output: `publish/ZipDrive.exe` (~74 MB) + `publish/appsettings.json`
 
 ## Configuration
 
-Configuration is loaded from `appsettings.json` and can be overridden via command-line arguments.
+All settings are read from `appsettings.json` (shipped alongside the executable). If everything is configured there, the executable can run without any command-line arguments:
+
+```bash
+ZipDrive.exe
+```
+
+Command-line arguments **override** `appsettings.json` values using the `--Section:Key=Value` syntax:
+
+```bash
+ZipDrive.exe --Mount:ArchiveDirectory="D:\my-zips" --Mount:MountPoint="Z:\"
+```
 
 ### Mount Options
 
@@ -71,7 +81,7 @@ Configuration is loaded from `appsettings.json` and can be overridden via comman
 | `Cache:MemoryCacheSizeMb` | `2048` | Memory tier capacity (MB) |
 | `Cache:DiskCacheSizeMb` | `10240` | Disk tier capacity (MB) |
 | `Cache:SmallFileCutoffMb` | `50` | Files smaller than this go to memory; larger go to disk |
-| `Cache:TempDirectory` | System temp | Directory for disk-cached temp files |
+| `Cache:TempDirectory` | System temp | Directory for disk-tier cache files. Set this to a fast SSD path to improve large-file read performance. When `null`, defaults to the OS temp directory |
 | `Cache:DefaultTtlMinutes` | `30` | Cache entry time-to-live |
 | `Cache:EvictionCheckIntervalSeconds` | `10` | Background maintenance sweep interval |
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Configuration is loaded from `appsettings.json` and can be overridden via comman
 | `Cache:SmallFileCutoffMb` | `50` | Files smaller than this go to memory; larger go to disk |
 | `Cache:TempDirectory` | System temp | Directory for disk-cached temp files |
 | `Cache:DefaultTtlMinutes` | `30` | Cache entry time-to-live |
-| `Cache:EvictionCheckIntervalSeconds` | `60` | Background maintenance sweep interval |
+| `Cache:EvictionCheckIntervalSeconds` | `10` | Background maintenance sweep interval |
 
 ### OpenTelemetry
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Configuration is loaded from `appsettings.json` and can be overridden via comman
 | `Mount:MountPoint` | `R:\` | Drive letter to mount |
 | `Mount:ArchiveDirectory` | (required) | Root directory containing ZIP archives |
 | `Mount:MaxDiscoveryDepth` | `6` | Maximum directory depth for archive discovery |
+| `Mount:ShortCircuitShellMetadata` | `true` | Skip Windows shell metadata probes (desktop.ini, thumbs.db, etc.) to avoid unnecessary ZIP parsing |
 
 ### Cache Options
 

--- a/src/ZipDrive.Cli/Program.cs
+++ b/src/ZipDrive.Cli/Program.cs
@@ -22,9 +22,13 @@ using MountOptions = ZipDrive.Infrastructure.FileSystem.MountOptions;
 // Required for ZIP entry name encoding
 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
-var version = Assembly.GetExecutingAssembly()
+var informationalVersion = Assembly.GetExecutingAssembly()
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
     ?.InformationalVersion ?? "unknown";
+
+// Strip the +commit-hash metadata suffix for cleaner display (e.g. "1.0.0-dev+abc123" → "1.0.0-dev")
+var plusIndex = informationalVersion.IndexOf('+');
+var version = plusIndex >= 0 ? informationalVersion[..plusIndex] : informationalVersion;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()

--- a/src/ZipDrive.Cli/appsettings.json
+++ b/src/ZipDrive.Cli/appsettings.json
@@ -10,7 +10,8 @@
   "Mount": {
     "MountPoint": "R:\\",
     "ArchiveDirectory": "",
-    "MaxDiscoveryDepth": 6
+    "MaxDiscoveryDepth": 6,
+    "ShortCircuitShellMetadata": true
   },
   "Cache": {
     "MemoryCacheSizeMb": 2048,
@@ -18,7 +19,7 @@
     "SmallFileCutoffMb": 50,
     "TempDirectory": null,
     "DefaultTtlMinutes": 30,
-    "EvictionCheckIntervalSeconds": 60
+    "EvictionCheckIntervalSeconds": 10
   },
   "OpenTelemetry": {
     "Endpoint": ""

--- a/src/ZipDrive.Infrastructure.FileSystem/DokanFileSystemAdapter.cs
+++ b/src/ZipDrive.Infrastructure.FileSystem/DokanFileSystemAdapter.cs
@@ -4,6 +4,7 @@ using System.Security.AccessControl;
 using DokanNet;
 using LTRData.Extensions.Native.Memory;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ZipDrive.Domain.Abstractions;
 using ZipDrive.Domain.Exceptions;
 using ZipDrive.Domain.Models;
@@ -19,11 +20,13 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
 {
     private readonly IVirtualFileSystem _vfs;
     private readonly ILogger<DokanFileSystemAdapter> _logger;
+    private readonly bool _shortCircuitShellMetadata;
 
-    public DokanFileSystemAdapter(IVirtualFileSystem vfs, ILogger<DokanFileSystemAdapter> logger)
+    public DokanFileSystemAdapter(IVirtualFileSystem vfs, ILogger<DokanFileSystemAdapter> logger, IOptions<MountOptions> mountOptions)
     {
         _vfs = vfs;
         _logger = logger;
+        _shortCircuitShellMetadata = mountOptions.Value.ShortCircuitShellMetadata;
     }
 
     public int DirectoryListingTimeoutResetIntervalMs => 0;
@@ -32,7 +35,15 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
         ReadOnlyNativeMemory<char> fileName, DokanNet.FileAccess access, FileShare share,
         FileMode mode, FileOptions options, FileAttributes attributes, ref DokanFileInfo info)
     {
+        // Short-circuit Windows shell metadata probes before allocating a string
+        if (_shortCircuitShellMetadata && ShellMetadataFilter.IsShellMetadataPath(fileName.Span))
+        {
+            _logger.LogDebug("CreateFile: short-circuit shell metadata: {Path}", fileName.Span.ToString());
+            return DokanResult.FileNotFound;
+        }
+
         string path = fileName.Span.ToString();
+        _logger.LogDebug("CreateFile: {Path} mode={Mode} access={Access}", path, mode, access);
 
         // Reject any create/write modes
         if (mode is FileMode.CreateNew or FileMode.Create or FileMode.Append)
@@ -71,6 +82,7 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
         out int bytesRead, long offset, ref DokanFileInfo info)
     {
         string path = fileName.Span.ToString();
+        _logger.LogDebug("ReadFile: {Path} offset={Offset} length={Length}", path, offset, buffer.Span.Length);
         bytesRead = 0;
         long startTimestamp = Stopwatch.GetTimestamp();
 
@@ -111,6 +123,7 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
         ref DokanFileInfo info)
     {
         string path = fileName.Span.ToString();
+        _logger.LogDebug("FindFiles: {Path}", path);
 
         try
         {
@@ -137,7 +150,7 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
     {
         string path = fileName.Span.ToString();
         string pattern = searchPattern.Span.ToString();
-
+        _logger.LogDebug("FindFilesWithPattern: {Path} pattern={Pattern}", path, pattern);
         try
         {
             IReadOnlyList<VfsFileInfo> entries = _vfs.ListDirectoryAsync(path).GetAwaiter().GetResult();
@@ -164,6 +177,7 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
         ref DokanFileInfo info)
     {
         string path = fileName.Span.ToString();
+        _logger.LogDebug("GetFileInformation: {Path}", path);
         fileInfo = default;
 
         try
@@ -199,6 +213,7 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
         NativeMemory<char> fileSystemName, out uint maximumComponentLength,
         ref uint volumeSerialNumber, ref DokanFileInfo info)
     {
+        _logger.LogDebug("GetVolumeInformation");
         volumeLabel.SetString("ZipDrive");
         fileSystemName.SetString("ZipDriveFS");
         maximumComponentLength = 256;
@@ -212,6 +227,7 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
         out long freeBytesAvailable, out long totalNumberOfBytes,
         out long totalNumberOfFreeBytes, ref DokanFileInfo info)
     {
+        _logger.LogDebug("GetDiskFreeSpace");
         freeBytesAvailable = 0;
         totalNumberOfFreeBytes = 0;
         totalNumberOfBytes = 0; // Read-only, no meaningful total
@@ -222,6 +238,7 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
         ReadOnlyNativeMemory<char> fileName, out FileSystemSecurity? security,
         AccessControlSections sections, ref DokanFileInfo info)
     {
+        _logger.LogDebug("GetFileSecurity: {Path}", fileName.Span.ToString());
         security = null;
         return DokanResult.NotImplemented;
     }
@@ -240,56 +257,103 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
 
     // === No-op lifecycle methods ===
 
-    public void Cleanup(ReadOnlyNativeMemory<char> fileName, ref DokanFileInfo info) { }
+    public void Cleanup(ReadOnlyNativeMemory<char> fileName, ref DokanFileInfo info)
+    {
+        _logger.LogDebug("Cleanup: {Path}", fileName.Span.ToString());
+    }
 
-    public void CloseFile(ReadOnlyNativeMemory<char> fileName, ref DokanFileInfo info) { }
+    public void CloseFile(ReadOnlyNativeMemory<char> fileName, ref DokanFileInfo info)
+    {
+        _logger.LogDebug("CloseFile: {Path}", fileName.Span.ToString());
+    }
 
     // === Read-only: all write ops return AccessDenied ===
 
     public NtStatus WriteFile(ReadOnlyNativeMemory<char> fileName, ReadOnlyNativeMemory<byte> buffer,
         out int bytesWritten, long offset, ref DokanFileInfo info)
-    { bytesWritten = 0; return DokanResult.AccessDenied; }
+    {
+        _logger.LogDebug("WriteFile: {Path}", fileName.Span.ToString());
+        bytesWritten = 0;
+        return DokanResult.AccessDenied;
+    }
 
     public NtStatus DeleteFile(ReadOnlyNativeMemory<char> fileName, ref DokanFileInfo info)
-        => DokanResult.AccessDenied;
+    {
+        _logger.LogDebug("DeleteFile: {Path}", fileName.Span.ToString());
+        return DokanResult.AccessDenied;
+    }
 
     public NtStatus DeleteDirectory(ReadOnlyNativeMemory<char> fileName, ref DokanFileInfo info)
-        => DokanResult.AccessDenied;
+    {
+        _logger.LogDebug("DeleteDirectory: {Path}", fileName.Span.ToString());
+        return DokanResult.AccessDenied;
+    }
 
     public NtStatus MoveFile(ReadOnlyNativeMemory<char> oldName, ReadOnlyNativeMemory<char> newName,
         bool replace, ref DokanFileInfo info)
-        => DokanResult.AccessDenied;
+    {
+        _logger.LogDebug("MoveFile: {OldPath} -> {NewPath}", oldName.Span.ToString(), newName.Span.ToString());
+        return DokanResult.AccessDenied;
+    }
 
     public NtStatus SetFileAttributes(ReadOnlyNativeMemory<char> fileName,
         FileAttributes attributes, ref DokanFileInfo info)
-        => DokanResult.AccessDenied;
+    {
+        _logger.LogDebug("SetFileAttributes: {Path}", fileName.Span.ToString());
+        return DokanResult.AccessDenied;
+    }
 
     public NtStatus SetFileTime(ReadOnlyNativeMemory<char> fileName,
         DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, ref DokanFileInfo info)
-        => DokanResult.AccessDenied;
+    {
+        _logger.LogDebug("SetFileTime: {Path}", fileName.Span.ToString());
+        return DokanResult.AccessDenied;
+    }
 
     public NtStatus SetEndOfFile(ReadOnlyNativeMemory<char> fileName, long length, ref DokanFileInfo info)
-        => DokanResult.AccessDenied;
+    {
+        _logger.LogDebug("SetEndOfFile: {Path}", fileName.Span.ToString());
+        return DokanResult.AccessDenied;
+    }
 
     public NtStatus SetAllocationSize(ReadOnlyNativeMemory<char> fileName, long length, ref DokanFileInfo info)
-        => DokanResult.AccessDenied;
+    {
+        _logger.LogDebug("SetAllocationSize: {Path}", fileName.Span.ToString());
+        return DokanResult.AccessDenied;
+    }
 
     public NtStatus SetFileSecurity(ReadOnlyNativeMemory<char> fileName,
         FileSystemSecurity security, AccessControlSections sections, ref DokanFileInfo info)
-        => DokanResult.AccessDenied;
+    {
+        _logger.LogDebug("SetFileSecurity: {Path}", fileName.Span.ToString());
+        return DokanResult.AccessDenied;
+    }
 
     public NtStatus FlushFileBuffers(ReadOnlyNativeMemory<char> fileName, ref DokanFileInfo info)
-        => DokanResult.Success;
+    {
+        _logger.LogDebug("FlushFileBuffers: {Path}", fileName.Span.ToString());
+        return DokanResult.Success;
+    }
 
     public NtStatus LockFile(ReadOnlyNativeMemory<char> fileName, long offset, long length, ref DokanFileInfo info)
-        => DokanResult.NotImplemented;
+    {
+        _logger.LogDebug("LockFile: {Path} offset={Offset} length={Length}", fileName.Span.ToString(), offset, length);
+        return DokanResult.NotImplemented;
+    }
 
     public NtStatus UnlockFile(ReadOnlyNativeMemory<char> fileName, long offset, long length, ref DokanFileInfo info)
-        => DokanResult.NotImplemented;
+    {
+        _logger.LogDebug("UnlockFile: {Path} offset={Offset} length={Length}", fileName.Span.ToString(), offset, length);
+        return DokanResult.NotImplemented;
+    }
 
     public NtStatus FindStreams(ReadOnlyNativeMemory<char> fileName,
         out IEnumerable<FindFileInformation> streams, ref DokanFileInfo info)
-    { streams = []; return DokanResult.NotImplemented; }
+    {
+        _logger.LogDebug("FindStreams: {Path}", fileName.Span.ToString());
+        streams = [];
+        return DokanResult.NotImplemented;
+    }
 
     // === Helpers ===
 

--- a/src/ZipDrive.Infrastructure.FileSystem/DokanFileSystemAdapter.cs
+++ b/src/ZipDrive.Infrastructure.FileSystem/DokanFileSystemAdapter.cs
@@ -38,7 +38,8 @@ public sealed class DokanFileSystemAdapter : IDokanOperations2
         // Short-circuit Windows shell metadata probes before allocating a string
         if (_shortCircuitShellMetadata && ShellMetadataFilter.IsShellMetadataPath(fileName.Span))
         {
-            _logger.LogDebug("CreateFile: short-circuit shell metadata: {Path}", fileName.Span.ToString());
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("CreateFile: short-circuit shell metadata: {Path}", fileName.Span.ToString());
             return DokanResult.FileNotFound;
         }
 

--- a/src/ZipDrive.Infrastructure.FileSystem/MountOptions.cs
+++ b/src/ZipDrive.Infrastructure.FileSystem/MountOptions.cs
@@ -19,4 +19,10 @@ public class MountOptions
     /// Maximum directory depth for ZIP discovery (1-6).
     /// </summary>
     public int MaxDiscoveryDepth { get; set; } = 6;
+
+    /// <summary>
+    /// When true, short-circuits Windows shell metadata file probes (desktop.ini, Thumbs.db, etc.)
+    /// to avoid unnecessarily parsing ZIP archives. Default is true.
+    /// </summary>
+    public bool ShortCircuitShellMetadata { get; set; } = true;
 }

--- a/src/ZipDrive.Infrastructure.FileSystem/ShellMetadataFilter.cs
+++ b/src/ZipDrive.Infrastructure.FileSystem/ShellMetadataFilter.cs
@@ -1,0 +1,67 @@
+namespace ZipDrive.Infrastructure.FileSystem;
+
+/// <summary>
+/// Identifies Windows shell metadata paths that never exist inside ZIP archives.
+/// Short-circuiting these in the Dokan adapter avoids eagerly parsing ZIP Central
+/// Directories just to return FileNotFound for probes like <c>\archive.zip\desktop.ini</c>.
+/// </summary>
+public static class ShellMetadataFilter
+{
+    /// <summary>
+    /// Windows Explorer metadata filenames that never exist inside ZIP archives.
+    /// </summary>
+    private static readonly string[] MetadataFileNames =
+    [
+        "desktop.ini",
+        "autorun.inf",
+        "thumbs.db",
+        "folder.jpg",
+        "folder.gif",
+        "icon.ico",
+    ];
+
+    /// <summary>
+    /// Top-level path segments probed by Windows shell that never exist inside archives.
+    /// </summary>
+    private static readonly string[] MetadataPathPrefixes =
+    [
+        "$RECYCLE.BIN",
+        "System Volume Information",
+    ];
+
+    /// <summary>
+    /// Returns true if <paramref name="path"/> targets a Windows shell metadata file
+    /// or a well-known shell prefix that can never exist inside a ZIP archive.
+    /// Zero-allocation: works directly on the span without converting to string.
+    /// </summary>
+    public static bool IsShellMetadataPath(ReadOnlySpan<char> path)
+    {
+        // Check the last segment (filename) against known metadata filenames
+        int lastSep = path.LastIndexOf('\\');
+        ReadOnlySpan<char> lastSegment = lastSep >= 0 ? path[(lastSep + 1)..] : path;
+
+        if (lastSegment.Length > 0 && SpanMatchesAny(lastSegment, MetadataFileNames))
+            return true;
+
+        // Check the first meaningful path segment against known shell prefixes
+        // e.g., \$RECYCLE.BIN or \System Volume Information
+        ReadOnlySpan<char> trimmed = path.TrimStart('\\');
+        int sep = trimmed.IndexOf('\\');
+        ReadOnlySpan<char> firstSegment = sep >= 0 ? trimmed[..sep] : trimmed;
+
+        if (firstSegment.Length > 0 && SpanMatchesAny(firstSegment, MetadataPathPrefixes))
+            return true;
+
+        return false;
+    }
+
+    private static bool SpanMatchesAny(ReadOnlySpan<char> value, string[] candidates)
+    {
+        foreach (string candidate in candidates)
+        {
+            if (value.Equals(candidate, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}

--- a/tests/ZipDrive.IntegrationTests/ShellMetadataFilterTests.cs
+++ b/tests/ZipDrive.IntegrationTests/ShellMetadataFilterTests.cs
@@ -19,6 +19,8 @@ public class ShellMetadataFilterTests
     [InlineData(@"\archive.zip\folder.jpg")]
     [InlineData(@"\archive.zip\folder.gif")]
     [InlineData(@"\archive.zip\icon.ico")]
+    [InlineData(@"\archive.zip\subfolder\desktop.ini")]
+    [InlineData(@"\archive.zip\a\b\c\thumbs.db")]
     public void IsShellMetadataPath_ReturnsTrue_ForKnownMetadataFiles(string path)
     {
         ShellMetadataFilter.IsShellMetadataPath(path).Should().BeTrue();
@@ -47,6 +49,8 @@ public class ShellMetadataFilterTests
     [InlineData(@"\archive.zip\subfolder\image.jpg")]
     [InlineData(@"\2000\archive.zip\photo.jpg")]
     [InlineData(@"\archive.zip\folder")]
+    [InlineData(@"\archive.zip\$RECYCLE.BIN\file.txt")]
+    [InlineData(@"\folder\System Volume Information\file.txt")]
     public void IsShellMetadataPath_ReturnsFalse_ForNormalPaths(string path)
     {
         ShellMetadataFilter.IsShellMetadataPath(path).Should().BeFalse();

--- a/tests/ZipDrive.IntegrationTests/ShellMetadataFilterTests.cs
+++ b/tests/ZipDrive.IntegrationTests/ShellMetadataFilterTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using ZipDrive.Infrastructure.FileSystem;
+
+namespace ZipDrive.IntegrationTests;
+
+public class ShellMetadataFilterTests
+{
+    // === Shell metadata filenames ===
+
+    [Theory]
+    [InlineData(@"\archive.zip\desktop.ini")]
+    [InlineData(@"\archive.zip\Desktop.INI")]
+    [InlineData(@"\archive.zip\DESKTOP.INI")]
+    [InlineData(@"\2000\archive.zip\desktop.ini")]
+    [InlineData(@"\archive.zip\autorun.inf")]
+    [InlineData(@"\archive.zip\AutoRun.Inf")]
+    [InlineData(@"\archive.zip\thumbs.db")]
+    [InlineData(@"\archive.zip\Thumbs.db")]
+    [InlineData(@"\archive.zip\folder.jpg")]
+    [InlineData(@"\archive.zip\folder.gif")]
+    [InlineData(@"\archive.zip\icon.ico")]
+    public void IsShellMetadataPath_ReturnsTrue_ForKnownMetadataFiles(string path)
+    {
+        ShellMetadataFilter.IsShellMetadataPath(path).Should().BeTrue();
+    }
+
+    // === Shell metadata prefixes ===
+
+    [Theory]
+    [InlineData(@"\$RECYCLE.BIN")]
+    [InlineData(@"\$RECYCLE.BIN\something")]
+    [InlineData(@"\$Recycle.Bin\file.txt")]
+    [InlineData(@"\System Volume Information")]
+    [InlineData(@"\System Volume Information\tracking.log")]
+    public void IsShellMetadataPath_ReturnsTrue_ForKnownPrefixes(string path)
+    {
+        ShellMetadataFilter.IsShellMetadataPath(path).Should().BeTrue();
+    }
+
+    // === Paths that should NOT be short-circuited ===
+
+    [Theory]
+    [InlineData(@"\")]
+    [InlineData(@"\2000")]
+    [InlineData(@"\archive.zip")]
+    [InlineData(@"\archive.zip\readme.txt")]
+    [InlineData(@"\archive.zip\subfolder\image.jpg")]
+    [InlineData(@"\2000\archive.zip\photo.jpg")]
+    [InlineData(@"\archive.zip\folder")]
+    public void IsShellMetadataPath_ReturnsFalse_ForNormalPaths(string path)
+    {
+        ShellMetadataFilter.IsShellMetadataPath(path).Should().BeFalse();
+    }
+
+    // === MountOptions default ===
+
+    [Fact]
+    public void MountOptions_ShortCircuitShellMetadata_DefaultsToTrue()
+    {
+        var opts = new MountOptions();
+        opts.ShortCircuitShellMetadata.Should().BeTrue();
+    }
+}

--- a/tests/ZipDrive.IntegrationTests/ZipDrive.IntegrationTests.csproj
+++ b/tests/ZipDrive.IntegrationTests/ZipDrive.IntegrationTests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\src\ZipDrive.Application\ZipDrive.Application.csproj" />
     <ProjectReference Include="..\..\src\ZipDrive.Infrastructure.Caching\ZipDrive.Infrastructure.Caching.csproj" />
     <ProjectReference Include="..\..\src\ZipDrive.Infrastructure.Archives.Zip\ZipDrive.Infrastructure.Archives.Zip.csproj" />
+    <ProjectReference Include="..\..\src\ZipDrive.Infrastructure.FileSystem\ZipDrive.Infrastructure.FileSystem.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- **Shell metadata short-circuit**: Windows Explorer probes every folder for `desktop.ini`, `thumbs.db`, `autorun.inf`, etc. These probes previously triggered full ZIP Central Directory parsing just to return `FileNotFound`. A new `ShellMetadataFilter` intercepts these paths using zero-allocation `ReadOnlySpan<char>` matching *before* any string allocation, returning `FileNotFound` immediately.
- **Debug logging**: All Dokan file system operations (`CreateFile`, `ReadFile`, `FindFiles`, `GetFileInformation`, `Cleanup`, `CloseFile`, `WriteFile`, etc.) now log at `Debug` level with the command name and file path. The short-circuit log is guarded with `IsEnabled(LogLevel.Debug)` to avoid allocation at normal log levels.
- **Configurable toggle**: `Mount:ShortCircuitShellMetadata` in `appsettings.json` (default: `true`) controls whether the filter is active.
- **Version display**: Startup log now strips the `+commit-hash` metadata suffix for cleaner display (e.g., `ZipDrive 1.0.0` instead of `1.0.0+abc123`).
- **Config change**: `Cache:EvictionCheckIntervalSeconds` default changed from `60` to `10` in `appsettings.json` for more responsive cache maintenance.

## Changes

- `ShellMetadataFilter.cs` — New zero-allocation static helper class matching known shell metadata filenames and path prefixes
- `DokanFileSystemAdapter.cs` — Debug logging for all operations + short-circuit call in `CreateFile`
- `MountOptions.cs` — New `ShortCircuitShellMetadata` property (default: `true`)
- `appsettings.json` — Added `ShortCircuitShellMetadata` setting; changed `EvictionCheckIntervalSeconds` from 60 to 10
- `Program.cs` — Strip `+commit-hash` from version display
- `ShellMetadataFilterTests.cs` — 28 integration tests covering filenames, prefixes, nested paths, case-insensitivity, and negative cases
- `CLAUDE.md` / `README.md` — Documentation updates

## Test plan

- [x] 28 `ShellMetadataFilterTests` pass (filenames, prefixes, nested paths, non-top-level prefixes, normal paths, MountOptions default)
- [x] All existing tests continue to pass
- [x] Published build tested manually with Windows Explorer browsing ZIP archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)