### PR TITLE
feat(cache): add per-process disk cache directory isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,4 +402,5 @@ FodyWeavers.xsd
 # ZipDrive project-specific
 test-archives/
 *.zip2vd.cache
+appsettings.dev.jsonc
 

--- a/openspec/changes/archive/2026-02-26-per-process-disk-cache/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-26-per-process-disk-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-25

--- a/openspec/changes/archive/2026-02-26-per-process-disk-cache/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-26-per-process-disk-cache/.openspec.yaml
@@ -1,2 +1,2 @@
 schema: spec-driven
-created: 2026-02-25
+created: 2026-02-26

--- a/openspec/changes/archive/2026-02-26-per-process-disk-cache/design.md
+++ b/openspec/changes/archive/2026-02-26-per-process-disk-cache/design.md
@@ -5,14 +5,13 @@
 When multiple ZipDrive processes run concurrently (mounting different drive letters), all processes share the same flat directory. Crashed processes leave orphaned cache files with no way to identify which process created them.
 
 **Constraints:**
-- `DiskStorageStrategy` is constructed inside `DualTierFileCache` which receives `IOptions<CacheOptions>` and has no access to `MountSettings`.
 - `CacheMaintenanceService` already handles final cleanup via `_fileCache.Clear()`.
 - The existing `IStorageStrategy<T>` interface and `GenericCache<T>` must not change — this is internal to `DiskStorageStrategy`.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Isolate disk cache files per process using `ZipDrive-{pid}-{mountLetter}` subdirectory
+- Isolate disk cache files per process using `ZipDrive-{pid}` subdirectory
 - Clean up the entire subdirectory on graceful shutdown
 - Keep it simple — no orphan cleanup, no lock files
 
@@ -23,47 +22,29 @@ When multiple ZipDrive processes run concurrently (mounting different drive lett
 
 ## Decisions
 
-### Decision 1: Subdirectory naming — `ZipDrive-{pid}-{mountLetter}`
+### Decision 1: Subdirectory naming — `ZipDrive-{pid}`
 
-**Choice:** Create subdirectory named `ZipDrive-{pid}-{mountLetter}` under the base temp directory. Example: `Z:\Temp\ZipDrive-12345-R\`.
+**Choice:** Create subdirectory named `ZipDrive-{pid}` under the base temp directory. Example: `Z:\Temp\ZipDrive-12345\`.
 
-The mount letter is extracted from `MountSettings.MountPoint` (first character, e.g., `R` from `R:\`). The PID comes from `Environment.ProcessId`.
+The PID comes from `Environment.ProcessId`.
 
 **Alternatives considered:**
 - `ZipDrive-{guid}`: Not human-readable, can't correlate to running process.
-- `ZipDrive-{pid}` only: Less descriptive when debugging; can't tell which mount point a cache dir belongs to.
+- `ZipDrive-{pid}-{mountLetter}`: Adds unnecessary complexity. PID alone uniquely identifies the process, and adding mount letter would require threading `MountSettings` through the caching infrastructure.
 
-**Rationale:** Human-readable, debuggable. `tasklist | findstr 12345` immediately tells you if the process is alive. The mount letter distinguishes cache directories when a single machine runs multiple ZipDrive instances.
+**Rationale:** Human-readable, debuggable. `tasklist | findstr 12345` immediately tells you if the process is alive. Simple — no dependency on `MountSettings`.
 
-### Decision 2: Pass mount letter through DualTierFileCache
+### Decision 2: DiskStorageStrategy owns subdirectory creation
 
-**Choice:** Add `IOptions<MountSettings>` as a constructor parameter of `DualTierFileCache`. Extract the drive letter and pass it to `DiskStorageStrategy` as a new `string processSubdirectory` parameter.
-
-`DualTierFileCache` computes: `$"ZipDrive-{Environment.ProcessId}-{mountSettings.MountPoint[0]}"` and passes the full subdirectory name.
+**Choice:** `DiskStorageStrategy` always creates a `ZipDrive-{pid}` subdirectory in its constructor. No external parameters needed — the strategy computes the name internally using `Environment.ProcessId`.
 
 **Alternatives considered:**
-- Inject `MountSettings` directly into `DiskStorageStrategy`: Strategy is a low-level component; adding config dependency feels wrong.
-- Compute in `Program.cs` and override `CacheOptions.TempDirectory`: Would work but loses the semantic separation (user's configured base dir vs computed process dir).
+- Pass subdirectory name from `DualTierFileCache`: Leaks an implementation detail upward.
+- Pass `IOptions<MountSettings>` to compute mount letter: Adds config dependency to a low-level component for no practical benefit.
 
-**Rationale:** `DualTierFileCache` already receives `IOptions<CacheOptions>`, making it the natural place to also receive `IOptions<MountSettings>`. It already owns the construction of `DiskStorageStrategy`. The strategy stays config-agnostic — it just receives a directory string.
+**Rationale:** `DiskStorageStrategy` is the right owner — it knows about its temp directory and should manage its own subdirectory structure. The constructor computes `Path.Combine(baseDir, $"ZipDrive-{Environment.ProcessId}")` and creates the directory.
 
-### Decision 3: DiskStorageStrategy creates and owns the process subdirectory
-
-**Choice:** `DiskStorageStrategy` constructor receives the full resolved directory path (base + process subdirectory), creates it if it doesn't exist (existing behavior), and stores files there (existing behavior). A new `DeleteDirectory()` method deletes the entire directory recursively.
-
-```
-Constructor:
-  _tempDirectory = Path.Combine(baseDir, processSubdirectory)
-  Directory.CreateDirectory(_tempDirectory)
-  // Files go into _tempDirectory as before
-
-DeleteDirectory():
-  Directory.Delete(_tempDirectory, recursive: true)
-```
-
-**Rationale:** Minimal change to `DiskStorageStrategy`. The constructor already creates directories. The only new behavior is directory-level cleanup (previously files were deleted individually by `Dispose(StoredEntry)`, the directory was never touched).
-
-### Decision 4: Cleanup chain — Clear() then DeleteDirectory()
+### Decision 3: Cleanup chain — Clear() then DeleteCacheDirectory()
 
 **Choice:** On shutdown:
 1. `CacheMaintenanceService` calls `_fileCache.Clear()` (existing) — deletes individual cache files
@@ -75,8 +56,6 @@ The directory delete is best-effort (logged warning on failure). Even if individ
 
 ## Risks / Trade-offs
 
-**[Mount letter extraction assumes standard drive letter format]** — `MountSettings.MountPoint[0]` assumes the mount point starts with a drive letter (e.g., `R:\`). Dokan also supports UNC mount paths (`\\mount\point`), but ZipDrive's current config only uses drive letters. If UNC support is added later, the extraction logic would need updating. Low risk — UNC mount is not in scope.
-
-**[PID reuse after crash]** — A crashed process's orphan directory (e.g., `ZipDrive-12345-R`) could collide with a new process that happens to get PID 12345 and mounts the same letter. This is extremely unlikely (PID reuse + same letter + same base dir) and harmless (the new process would just reuse the directory and clean it up on exit). No mitigation needed.
+**[PID reuse after crash]** — A crashed process's orphan directory (e.g., `ZipDrive-12345`) could collide with a new process that happens to get PID 12345. This is extremely unlikely and harmless (the new process would just reuse the directory and clean it up on exit). No mitigation needed.
 
 **[Directory.Delete may fail if files are locked by OS]** — Memory-mapped files can keep file handles open briefly after `MemoryMappedFile.Dispose()`. If `DeleteCacheDirectory` runs before the OS fully releases handles, it may fail. Mitigation: `Clear()` already disposes all MMFs first, and the delete is best-effort with warning log.

--- a/openspec/changes/archive/2026-02-26-per-process-disk-cache/design.md
+++ b/openspec/changes/archive/2026-02-26-per-process-disk-cache/design.md
@@ -1,0 +1,82 @@
+## Context
+
+`DiskStorageStrategy` currently receives a `tempDirectory` string (or null for system temp), ensures the directory exists, and writes cache files directly into it as `{Guid}.zip2vd.cache`. On shutdown, `CacheMaintenanceService.Clear()` calls `GenericCache.Clear()` which disposes individual cache files (deleting each temp file). The directory itself is never cleaned up.
+
+When multiple ZipDrive processes run concurrently (mounting different drive letters), all processes share the same flat directory. Crashed processes leave orphaned cache files with no way to identify which process created them.
+
+**Constraints:**
+- `DiskStorageStrategy` is constructed inside `DualTierFileCache` which receives `IOptions<CacheOptions>` and has no access to `MountSettings`.
+- `CacheMaintenanceService` already handles final cleanup via `_fileCache.Clear()`.
+- The existing `IStorageStrategy<T>` interface and `GenericCache<T>` must not change — this is internal to `DiskStorageStrategy`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Isolate disk cache files per process using `ZipDrive-{pid}-{mountLetter}` subdirectory
+- Clean up the entire subdirectory on graceful shutdown
+- Keep it simple — no orphan cleanup, no lock files
+
+**Non-Goals:**
+- Automatic orphan cleanup on startup (user can clean manually)
+- Cross-process cache sharing or coordination
+- Changes to `IStorageStrategy<T>` interface or `GenericCache<T>`
+
+## Decisions
+
+### Decision 1: Subdirectory naming — `ZipDrive-{pid}-{mountLetter}`
+
+**Choice:** Create subdirectory named `ZipDrive-{pid}-{mountLetter}` under the base temp directory. Example: `Z:\Temp\ZipDrive-12345-R\`.
+
+The mount letter is extracted from `MountSettings.MountPoint` (first character, e.g., `R` from `R:\`). The PID comes from `Environment.ProcessId`.
+
+**Alternatives considered:**
+- `ZipDrive-{guid}`: Not human-readable, can't correlate to running process.
+- `ZipDrive-{pid}` only: Less descriptive when debugging; can't tell which mount point a cache dir belongs to.
+
+**Rationale:** Human-readable, debuggable. `tasklist | findstr 12345` immediately tells you if the process is alive. The mount letter distinguishes cache directories when a single machine runs multiple ZipDrive instances.
+
+### Decision 2: Pass mount letter through DualTierFileCache
+
+**Choice:** Add `IOptions<MountSettings>` as a constructor parameter of `DualTierFileCache`. Extract the drive letter and pass it to `DiskStorageStrategy` as a new `string processSubdirectory` parameter.
+
+`DualTierFileCache` computes: `$"ZipDrive-{Environment.ProcessId}-{mountSettings.MountPoint[0]}"` and passes the full subdirectory name.
+
+**Alternatives considered:**
+- Inject `MountSettings` directly into `DiskStorageStrategy`: Strategy is a low-level component; adding config dependency feels wrong.
+- Compute in `Program.cs` and override `CacheOptions.TempDirectory`: Would work but loses the semantic separation (user's configured base dir vs computed process dir).
+
+**Rationale:** `DualTierFileCache` already receives `IOptions<CacheOptions>`, making it the natural place to also receive `IOptions<MountSettings>`. It already owns the construction of `DiskStorageStrategy`. The strategy stays config-agnostic — it just receives a directory string.
+
+### Decision 3: DiskStorageStrategy creates and owns the process subdirectory
+
+**Choice:** `DiskStorageStrategy` constructor receives the full resolved directory path (base + process subdirectory), creates it if it doesn't exist (existing behavior), and stores files there (existing behavior). A new `DeleteDirectory()` method deletes the entire directory recursively.
+
+```
+Constructor:
+  _tempDirectory = Path.Combine(baseDir, processSubdirectory)
+  Directory.CreateDirectory(_tempDirectory)
+  // Files go into _tempDirectory as before
+
+DeleteDirectory():
+  Directory.Delete(_tempDirectory, recursive: true)
+```
+
+**Rationale:** Minimal change to `DiskStorageStrategy`. The constructor already creates directories. The only new behavior is directory-level cleanup (previously files were deleted individually by `Dispose(StoredEntry)`, the directory was never touched).
+
+### Decision 4: Cleanup chain — Clear() then DeleteDirectory()
+
+**Choice:** On shutdown:
+1. `CacheMaintenanceService` calls `_fileCache.Clear()` (existing) — deletes individual cache files
+2. `CacheMaintenanceService` calls a new `_fileCache.DeleteCacheDirectory()` method — removes the now-empty subdirectory
+
+The directory delete is best-effort (logged warning on failure). Even if individual file cleanup fails, `Directory.Delete(recursive: true)` will catch remaining files.
+
+**Rationale:** Two-phase cleanup is defensive. If `Clear()` successfully removes all files, the directory delete is trivial. If some files linger (MMF still held by OS), the recursive delete catches them. If both fail, the orphan directory stays — acceptable per non-goal.
+
+## Risks / Trade-offs
+
+**[Mount letter extraction assumes standard drive letter format]** — `MountSettings.MountPoint[0]` assumes the mount point starts with a drive letter (e.g., `R:\`). Dokan also supports UNC mount paths (`\\mount\point`), but ZipDrive's current config only uses drive letters. If UNC support is added later, the extraction logic would need updating. Low risk — UNC mount is not in scope.
+
+**[PID reuse after crash]** — A crashed process's orphan directory (e.g., `ZipDrive-12345-R`) could collide with a new process that happens to get PID 12345 and mounts the same letter. This is extremely unlikely (PID reuse + same letter + same base dir) and harmless (the new process would just reuse the directory and clean it up on exit). No mitigation needed.
+
+**[Directory.Delete may fail if files are locked by OS]** — Memory-mapped files can keep file handles open briefly after `MemoryMappedFile.Dispose()`. If `DeleteCacheDirectory` runs before the OS fully releases handles, it may fail. Mitigation: `Clear()` already disposes all MMFs first, and the delete is best-effort with warning log.

--- a/openspec/changes/archive/2026-02-26-per-process-disk-cache/proposal.md
+++ b/openspec/changes/archive/2026-02-26-per-process-disk-cache/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+When multiple ZipDrive processes mount different drive letters concurrently (e.g., Process 1 mounts R:\, Process 2 mounts S:\), all disk-tier cache files land in the same flat directory (`TempDirectory` or `%TEMP%`). While GUID-named files avoid collisions, this creates two problems:
+
+1. **No process isolation** — orphaned `.zip2vd.cache` files from a crashed process are indistinguishable from files belonging to a running process. No way to clean up selectively.
+2. **Cluttered shared directory** — hundreds of cache files from multiple processes intermixed in one flat directory, making debugging and manual cleanup difficult.
+
+## What Changes
+
+- **Per-process subdirectory**: `DiskStorageStrategy` creates a subdirectory `ZipDrive-{pid}-{mountLetter}` under the configured `TempDirectory` (or system temp). All disk cache files for that process are stored inside this subdirectory.
+- **Directory cleanup on shutdown**: When the process exits cleanly, the entire `ZipDrive-{pid}-{mountLetter}` directory is deleted recursively (after the existing `Clear()` deletes individual cache files).
+- **MountSettings dependency**: `DiskStorageStrategy` (or its caller) needs the mount point letter to construct the directory name.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `file-content-cache`: DiskStorageStrategy creates and cleans up a per-process subdirectory instead of storing files directly in TempDirectory.
+
+## Impact
+
+- **Modified files**: `DiskStorageStrategy.cs`, `DualTierFileCache.cs`, `CacheMaintenanceService.cs`, `appsettings.jsonc` (documentation comment only)
+- **No new NuGet dependencies**
+- **No breaking API changes** — `DiskStorageStrategy` constructor gains a `mountLetter` parameter, but this is internal infrastructure
+- **Test updates**: Existing `DiskStorageStrategy` tests in `GenericCacheIntegrationTests.cs` may need minor updates for the new subdirectory structure. New tests verify directory creation, cleanup on shutdown, and multi-instance isolation.

--- a/openspec/changes/archive/2026-02-26-per-process-disk-cache/proposal.md
+++ b/openspec/changes/archive/2026-02-26-per-process-disk-cache/proposal.md
@@ -7,9 +7,8 @@ When multiple ZipDrive processes mount different drive letters concurrently (e.g
 
 ## What Changes
 
-- **Per-process subdirectory**: `DiskStorageStrategy` creates a subdirectory `ZipDrive-{pid}-{mountLetter}` under the configured `TempDirectory` (or system temp). All disk cache files for that process are stored inside this subdirectory.
-- **Directory cleanup on shutdown**: When the process exits cleanly, the entire `ZipDrive-{pid}-{mountLetter}` directory is deleted recursively (after the existing `Clear()` deletes individual cache files).
-- **MountSettings dependency**: `DiskStorageStrategy` (or its caller) needs the mount point letter to construct the directory name.
+- **Per-process subdirectory**: `DiskStorageStrategy` always creates a subdirectory `ZipDrive-{pid}` under the configured `TempDirectory` (or system temp). All disk cache files for that process are stored inside this subdirectory.
+- **Directory cleanup on shutdown**: When the process exits cleanly, the entire `ZipDrive-{pid}` directory is deleted recursively (after the existing `Clear()` deletes individual cache files).
 
 ## Capabilities
 
@@ -19,7 +18,7 @@ When multiple ZipDrive processes mount different drive letters concurrently (e.g
 
 ## Impact
 
-- **Modified files**: `DiskStorageStrategy.cs`, `DualTierFileCache.cs`, `CacheMaintenanceService.cs`, `appsettings.jsonc` (documentation comment only)
+- **Modified files**: `DiskStorageStrategy.cs`, `DualTierFileCache.cs`, `CacheMaintenanceService.cs`
 - **No new NuGet dependencies**
-- **No breaking API changes** — `DiskStorageStrategy` constructor gains a `mountLetter` parameter, but this is internal infrastructure
-- **Test updates**: Existing `DiskStorageStrategy` tests in `GenericCacheIntegrationTests.cs` may need minor updates for the new subdirectory structure. New tests verify directory creation, cleanup on shutdown, and multi-instance isolation.
+- **No breaking API changes** — `DiskStorageStrategy` always creates the per-process subdirectory internally
+- **Test updates**: Existing `DiskStorageStrategy` tests in `GenericCacheIntegrationTests.cs` updated with `SearchOption.AllDirectories` for the new subdirectory structure. New tests verify directory creation, cleanup on shutdown, and null-tempDirectory fallback.

--- a/openspec/changes/archive/2026-02-26-per-process-disk-cache/specs/file-content-cache/spec.md
+++ b/openspec/changes/archive/2026-02-26-per-process-disk-cache/specs/file-content-cache/spec.md
@@ -1,0 +1,63 @@
+## Delta: Per-Process Disk Cache Directory
+
+### Requirement: Per-process cache directory isolation
+
+The disk storage strategy SHALL always create a per-process subdirectory under the configured TempDirectory (or system temp) to isolate cache files from concurrent ZipDrive processes.
+
+#### Scenario: Process subdirectory created on startup
+
+- **WHEN** `DiskStorageStrategy` is constructed
+- **THEN** a directory named `ZipDrive-{pid}` is created under the base temp directory
+- **AND** all subsequent cache files are stored inside this subdirectory
+- **AND** the directory is created if it does not already exist
+
+#### Scenario: Base temp directory created if missing
+
+- **WHEN** the configured `TempDirectory` does not exist
+- **THEN** the base directory is created first
+- **AND** then the process subdirectory is created inside it
+
+#### Scenario: Cache files stored in process subdirectory
+
+- **WHEN** `StoreAsync` creates a new cache file
+- **THEN** the file path is `{baseDir}/ZipDrive-{pid}/{guid}.zip2vd.cache`
+- **AND** the file is accessible via memory-mapped file as before
+
+---
+
+### Requirement: Process subdirectory cleanup on shutdown
+
+The disk storage strategy SHALL delete its entire process subdirectory on graceful shutdown, after individual cache files have been cleared.
+
+#### Scenario: Directory deleted on clean shutdown
+
+- **WHEN** `DeleteCacheDirectory()` is called after `Clear()`
+- **THEN** the `ZipDrive-{pid}` directory is deleted recursively
+- **AND** success is logged at Information level
+
+#### Scenario: Directory deletion failure is non-fatal
+
+- **WHEN** `DeleteCacheDirectory()` fails (e.g., file still locked by OS)
+- **THEN** a warning is logged with the exception details
+- **AND** the process continues to shut down normally
+- **AND** the orphaned directory remains on disk
+
+#### Scenario: CacheMaintenanceService invokes directory cleanup
+
+- **WHEN** `CacheMaintenanceService` stops (stoppingToken cancelled)
+- **THEN** it calls `_fileCache.Clear()` first (existing behavior)
+- **THEN** it calls `_fileCache.DeleteCacheDirectory()` to remove the process subdirectory
+
+---
+
+### Requirement: Multi-instance isolation
+
+Multiple concurrent ZipDrive processes SHALL have completely isolated disk cache directories.
+
+#### Scenario: Two processes use separate directories
+
+- **WHEN** Process A (PID 1000) and Process B (PID 2000) both run ZipDrive
+- **AND** both use the same base `TempDirectory`
+- **THEN** Process A's cache files are in `{baseDir}/ZipDrive-1000/`
+- **AND** Process B's cache files are in `{baseDir}/ZipDrive-2000/`
+- **AND** neither process interferes with the other's files

--- a/openspec/changes/archive/2026-02-26-per-process-disk-cache/tasks.md
+++ b/openspec/changes/archive/2026-02-26-per-process-disk-cache/tasks.md
@@ -1,51 +1,35 @@
 ## 1. DiskStorageStrategy — Per-Process Subdirectory
 
-- [x] 1.1 Add `string? processSubdirectory` parameter to `DiskStorageStrategy` constructor (after `tempDirectory`), default `null` for backward compatibility
-- [x] 1.2 In constructor: if `processSubdirectory` is not null, set `_tempDirectory = Path.Combine(baseDir, processSubdirectory)` instead of just `baseDir`
+- [x] 1.1 In constructor: always compute `_tempDirectory = Path.Combine(baseDir, $"ZipDrive-{Environment.ProcessId}")`
+- [x] 1.2 `Directory.CreateDirectory(_tempDirectory)` if it doesn't exist (existing pattern)
 - [x] 1.3 Add `DeleteCacheDirectory()` method that calls `Directory.Delete(_tempDirectory, recursive: true)` with try/catch logging
 - [x] 1.4 Build to verify compilation
 
-## 2. DualTierFileCache — Mount Letter Integration
+## 2. DualTierFileCache — Expose DeleteCacheDirectory
 
-- [x] 2.1 Add `IOptions<MountSettings>` constructor parameter to `DualTierFileCache`
-- [x] 2.2 Compute subdirectory name: `$"ZipDrive-{Environment.ProcessId}-{mountSettings.MountPoint[0]}"`
-- [x] 2.3 Pass computed subdirectory name to `DiskStorageStrategy` constructor
-- [x] 2.4 Add `DeleteCacheDirectory()` method that delegates to `DiskStorageStrategy` (expose via `_diskStorageStrategy` field)
-- [x] 2.5 Build to verify compilation
+- [x] 2.1 Keep `_diskStorageStrategy` field reference alongside `_diskCache` in `DualTierFileCache`
+- [x] 2.2 Add `DeleteCacheDirectory()` method that delegates to `_diskStorageStrategy.DeleteCacheDirectory()`
+- [x] 2.3 Build to verify compilation
 
-## 3. Expose DeleteCacheDirectory Through the Chain
+## 3. CacheMaintenanceService — Shutdown Cleanup
 
-- [x] 3.1 Add `DeleteCacheDirectory()` method to `DiskStorageStrategy` (done in 1.3)
-- [x] 3.2 `IStorageStrategy<T>` does NOT need to change — `DeleteCacheDirectory` is specific to `DiskStorageStrategy`
-- [x] 3.3 `DualTierFileCache` keeps a `_diskStorageStrategy` field reference alongside `_diskCache`
-- [x] 3.4 Build to verify compilation
+- [x] 3.1 After `_fileCache.Clear()` in the `ExecuteAsync` shutdown block, add `_fileCache.DeleteCacheDirectory()`
+- [x] 3.2 Wrap in try/catch with warning log on failure
+- [x] 3.3 Build to verify compilation
 
-## 4. CacheMaintenanceService — Shutdown Cleanup
+## 4. Fix Existing Tests
 
-- [x] 4.1 After `_fileCache.Clear()` in the `ExecuteAsync` shutdown block, add `_fileCache.DeleteCacheDirectory()`
-- [x] 4.2 Wrap in try/catch with warning log on failure
-- [x] 4.3 Build to verify compilation
+- [x] 4.1 `GenericCacheIntegrationTests.cs` — update `Directory.GetFiles` calls to use `SearchOption.AllDirectories`
+- [x] 4.2 `DualTierFileCacheTests.cs` — already uses `SearchOption.AllDirectories`
+- [x] 4.3 `EnduranceTest.cs`, `VfsTestFixture.cs`, `ZipVirtualFileSystemTests.cs` — no changes needed (`DualTierFileCache` constructor unchanged)
+- [x] 4.4 Build and run all existing tests — pass
 
-## 5. DI Wiring
+## 5. New Unit Tests
 
-- [x] 5.1 `IOptions<MountSettings>` already registered in `Program.cs` — no change needed
-- [x] 5.2 Build full solution — succeeded
-
-## 6. Fix Existing Tests
-
-- [x] 6.1 `GenericCacheIntegrationTests.cs` — backward-compatible, no changes needed (uses `null` processSubdirectory by default)
-- [x] 6.2 `DualTierFileCacheTests.cs` — added `IOptions<MountSettings>` with `MountPoint = "T:\"`
-- [x] 6.3 `EnduranceTest.cs` — added `IOptions<MountSettings>` with default `MountSettings`
-- [x] 6.4 `VfsTestFixture.cs` + `ZipVirtualFileSystemTests.cs` — added `IOptions<MountSettings>`
-- [x] 6.5 Build and run all existing tests — 242 tests pass, zero regressions
-
-## 7. New Unit Tests
-
-- [x] 7.1 Test: `DiskStorageStrategy` with `processSubdirectory` creates the subdirectory under the base temp dir
-- [x] 7.2 Test: `DiskStorageStrategy.StoreAsync` stores files inside the process subdirectory
-- [x] 7.3 Test: `DiskStorageStrategy.DeleteCacheDirectory` removes the entire subdirectory recursively
-- [x] 7.4 Test: `DiskStorageStrategy` with `processSubdirectory: null` behaves as before (backward compat)
-- [x] 7.5 Test: `DualTierFileCache` constructs correct subdirectory name from `MountSettings.MountPoint`
-- [x] 7.6 Test: `DualTierFileCache.DeleteCacheDirectory` removes the process subdirectory (via delegation)
-- [x] 7.7 Test: Two `DiskStorageStrategy` instances with different subdirectory names create isolated directories
-- [x] 7.8 Run full test suite — 249 tests pass (7 new + 242 existing)
+- [x] 5.1 Test: `DiskStorageStrategy` creates `ZipDrive-{pid}` subdirectory under base temp dir
+- [x] 5.2 Test: `DiskStorageStrategy.StoreAsync` stores files inside the process subdirectory
+- [x] 5.3 Test: `DiskStorageStrategy.DeleteCacheDirectory` removes the entire subdirectory recursively
+- [x] 5.4 Test: `DualTierFileCache` constructs correct `ZipDrive-{pid}` subdirectory
+- [x] 5.5 Test: `DualTierFileCache.DeleteCacheDirectory` removes the process subdirectory
+- [x] 5.6 Test: `DiskStorageStrategy` with null tempDirectory creates subdirectory under system temp
+- [x] 5.7 Run full test suite — 249 tests pass (6 new + existing)

--- a/openspec/changes/archive/2026-02-26-per-process-disk-cache/tasks.md
+++ b/openspec/changes/archive/2026-02-26-per-process-disk-cache/tasks.md
@@ -1,0 +1,51 @@
+## 1. DiskStorageStrategy — Per-Process Subdirectory
+
+- [x] 1.1 Add `string? processSubdirectory` parameter to `DiskStorageStrategy` constructor (after `tempDirectory`), default `null` for backward compatibility
+- [x] 1.2 In constructor: if `processSubdirectory` is not null, set `_tempDirectory = Path.Combine(baseDir, processSubdirectory)` instead of just `baseDir`
+- [x] 1.3 Add `DeleteCacheDirectory()` method that calls `Directory.Delete(_tempDirectory, recursive: true)` with try/catch logging
+- [x] 1.4 Build to verify compilation
+
+## 2. DualTierFileCache — Mount Letter Integration
+
+- [x] 2.1 Add `IOptions<MountSettings>` constructor parameter to `DualTierFileCache`
+- [x] 2.2 Compute subdirectory name: `$"ZipDrive-{Environment.ProcessId}-{mountSettings.MountPoint[0]}"`
+- [x] 2.3 Pass computed subdirectory name to `DiskStorageStrategy` constructor
+- [x] 2.4 Add `DeleteCacheDirectory()` method that delegates to `DiskStorageStrategy` (expose via `_diskStorageStrategy` field)
+- [x] 2.5 Build to verify compilation
+
+## 3. Expose DeleteCacheDirectory Through the Chain
+
+- [x] 3.1 Add `DeleteCacheDirectory()` method to `DiskStorageStrategy` (done in 1.3)
+- [x] 3.2 `IStorageStrategy<T>` does NOT need to change — `DeleteCacheDirectory` is specific to `DiskStorageStrategy`
+- [x] 3.3 `DualTierFileCache` keeps a `_diskStorageStrategy` field reference alongside `_diskCache`
+- [x] 3.4 Build to verify compilation
+
+## 4. CacheMaintenanceService — Shutdown Cleanup
+
+- [x] 4.1 After `_fileCache.Clear()` in the `ExecuteAsync` shutdown block, add `_fileCache.DeleteCacheDirectory()`
+- [x] 4.2 Wrap in try/catch with warning log on failure
+- [x] 4.3 Build to verify compilation
+
+## 5. DI Wiring
+
+- [x] 5.1 `IOptions<MountSettings>` already registered in `Program.cs` — no change needed
+- [x] 5.2 Build full solution — succeeded
+
+## 6. Fix Existing Tests
+
+- [x] 6.1 `GenericCacheIntegrationTests.cs` — backward-compatible, no changes needed (uses `null` processSubdirectory by default)
+- [x] 6.2 `DualTierFileCacheTests.cs` — added `IOptions<MountSettings>` with `MountPoint = "T:\"`
+- [x] 6.3 `EnduranceTest.cs` — added `IOptions<MountSettings>` with default `MountSettings`
+- [x] 6.4 `VfsTestFixture.cs` + `ZipVirtualFileSystemTests.cs` — added `IOptions<MountSettings>`
+- [x] 6.5 Build and run all existing tests — 242 tests pass, zero regressions
+
+## 7. New Unit Tests
+
+- [x] 7.1 Test: `DiskStorageStrategy` with `processSubdirectory` creates the subdirectory under the base temp dir
+- [x] 7.2 Test: `DiskStorageStrategy.StoreAsync` stores files inside the process subdirectory
+- [x] 7.3 Test: `DiskStorageStrategy.DeleteCacheDirectory` removes the entire subdirectory recursively
+- [x] 7.4 Test: `DiskStorageStrategy` with `processSubdirectory: null` behaves as before (backward compat)
+- [x] 7.5 Test: `DualTierFileCache` constructs correct subdirectory name from `MountSettings.MountPoint`
+- [x] 7.6 Test: `DualTierFileCache.DeleteCacheDirectory` removes the process subdirectory (via delegation)
+- [x] 7.7 Test: Two `DiskStorageStrategy` instances with different subdirectory names create isolated directories
+- [x] 7.8 Run full test suite — 249 tests pass (7 new + 242 existing)

--- a/openspec/specs/file-content-cache/spec.md
+++ b/openspec/specs/file-content-cache/spec.md
@@ -318,3 +318,67 @@ The cache SHALL log lifecycle events (materialization, eviction, TTL expiry) at 
 
 ---
 
+### Requirement: Per-process cache directory isolation
+
+The disk storage strategy SHALL always create a per-process subdirectory under the configured TempDirectory (or system temp) to isolate cache files from concurrent ZipDrive processes.
+
+#### Scenario: Process subdirectory created on startup
+
+- **WHEN** `DiskStorageStrategy` is constructed
+- **THEN** a directory named `ZipDrive-{pid}` is created under the base temp directory
+- **AND** all subsequent cache files are stored inside this subdirectory
+- **AND** the directory is created if it does not already exist
+
+#### Scenario: Base temp directory created if missing
+
+- **WHEN** the configured `TempDirectory` does not exist
+- **THEN** the base directory is created first
+- **AND** then the process subdirectory is created inside it
+
+#### Scenario: Cache files stored in process subdirectory
+
+- **WHEN** `StoreAsync` creates a new cache file
+- **THEN** the file path is `{baseDir}/ZipDrive-{pid}/{guid}.zip2vd.cache`
+- **AND** the file is accessible via memory-mapped file as before
+
+---
+
+### Requirement: Process subdirectory cleanup on shutdown
+
+The disk storage strategy SHALL delete its entire process subdirectory on graceful shutdown, after individual cache files have been cleared.
+
+#### Scenario: Directory deleted on clean shutdown
+
+- **WHEN** `DeleteCacheDirectory()` is called after `Clear()`
+- **THEN** the `ZipDrive-{pid}` directory is deleted recursively
+- **AND** success is logged at Information level
+
+#### Scenario: Directory deletion failure is non-fatal
+
+- **WHEN** `DeleteCacheDirectory()` fails (e.g., file still locked by OS)
+- **THEN** a warning is logged with the exception details
+- **AND** the process continues to shut down normally
+- **AND** the orphaned directory remains on disk
+
+#### Scenario: CacheMaintenanceService invokes directory cleanup
+
+- **WHEN** `CacheMaintenanceService` stops (stoppingToken cancelled)
+- **THEN** it calls `_fileCache.Clear()` first (existing behavior)
+- **THEN** it calls `_fileCache.DeleteCacheDirectory()` to remove the process subdirectory
+
+---
+
+### Requirement: Multi-instance isolation
+
+Multiple concurrent ZipDrive processes SHALL have completely isolated disk cache directories.
+
+#### Scenario: Two processes use separate directories
+
+- **WHEN** Process A (PID 1000) and Process B (PID 2000) both run ZipDrive
+- **AND** both use the same base `TempDirectory`
+- **THEN** Process A's cache files are in `{baseDir}/ZipDrive-1000/`
+- **AND** Process B's cache files are in `{baseDir}/ZipDrive-2000/`
+- **AND** neither process interferes with the other's files
+
+---
+

--- a/src/ZipDrive.Cli/Program.cs
+++ b/src/ZipDrive.Cli/Program.cs
@@ -44,6 +44,7 @@ var builder = Host.CreateDefaultBuilder(args)
         // Our JSONC file layers on top and overrides any values from a .json file.
         // We ship only appsettings.jsonc; no appsettings.json exists in output.
         config.AddJsonFile("appsettings.jsonc", optional: false, reloadOnChange: false);
+        config.AddJsonFile("appsettings.dev.jsonc", optional: true, reloadOnChange: false);
     });
 
 builder.UseSerilog((context, config) =>

--- a/src/ZipDrive.Cli/ZipDrive.Cli.csproj
+++ b/src/ZipDrive.Cli/ZipDrive.Cli.csproj
@@ -36,6 +36,9 @@
     <None Update="appsettings.jsonc">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="appsettings.dev.jsonc" Condition="Exists('appsettings.dev.jsonc')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/ZipDrive.Infrastructure.Caching/CacheMaintenanceService.cs
+++ b/src/ZipDrive.Infrastructure.Caching/CacheMaintenanceService.cs
@@ -75,6 +75,16 @@ public sealed class CacheMaintenanceService : BackgroundService
             _logger.LogWarning(ex, "Error during final cache cleanup");
         }
 
+        // Delete the per-process disk cache directory
+        try
+        {
+            _fileCache.DeleteCacheDirectory();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error deleting cache directory");
+        }
+
         _logger.LogInformation("CacheMaintenanceService stopped");
     }
 }

--- a/src/ZipDrive.Infrastructure.Caching/DiskStorageStrategy.cs
+++ b/src/ZipDrive.Infrastructure.Caching/DiskStorageStrategy.cs
@@ -16,18 +16,23 @@ public sealed class DiskStorageStrategy : IStorageStrategy<Stream>
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DiskStorageStrategy"/> class.
+    /// Creates a per-process subdirectory (ZipDrive-{pid}) under the base temp directory,
+    /// ensuring multiple concurrent ZipDrive processes have isolated disk caches.
     /// </summary>
-    /// <param name="tempDirectory">The directory for temporary cache files. If null, uses system temp.</param>
     /// <param name="logger">Logger instance.</param>
+    /// <param name="tempDirectory">The base directory for temporary cache files. If null, uses system temp.</param>
     public DiskStorageStrategy(ILogger<DiskStorageStrategy> logger, string? tempDirectory = null)
     {
-        _tempDirectory = tempDirectory ?? Path.GetTempPath();
         _logger = logger;
 
-        // Ensure temp directory exists
+        string baseDir = tempDirectory ?? Path.GetTempPath();
+        _tempDirectory = Path.Combine(baseDir, $"ZipDrive-{Environment.ProcessId}");
+
+        // Ensure temp directory exists (creates base + subdirectory as needed)
         if (!Directory.Exists(_tempDirectory))
         {
             Directory.CreateDirectory(_tempDirectory);
+            _logger.LogInformation("Created cache directory: {Path}", _tempDirectory);
         }
     }
 
@@ -102,6 +107,26 @@ public sealed class DiskStorageStrategy : IStorageStrategy<Stream>
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to delete temp file: {Path}", entry.TempFilePath);
+        }
+    }
+
+    /// <summary>
+    /// Deletes the entire cache directory (including any remaining files).
+    /// Call after <see cref="GenericCache{T}.Clear"/> on shutdown.
+    /// </summary>
+    public void DeleteCacheDirectory()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+                _logger.LogInformation("Deleted cache directory: {Path}", _tempDirectory);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete cache directory: {Path}", _tempDirectory);
         }
     }
 

--- a/src/ZipDrive.Infrastructure.Caching/DualTierFileCache.cs
+++ b/src/ZipDrive.Infrastructure.Caching/DualTierFileCache.cs
@@ -11,6 +11,7 @@ public sealed class DualTierFileCache : ICache<Stream>
 {
     private readonly GenericCache<Stream> _memoryCache;
     private readonly GenericCache<Stream> _diskCache;
+    private readonly DiskStorageStrategy _diskStorageStrategy;
     private readonly long _cutoffBytes;
     private readonly ILogger<DualTierFileCache> _logger;
 
@@ -36,9 +37,12 @@ public sealed class DualTierFileCache : ICache<Stream>
             loggerFactory.CreateLogger<GenericCache<Stream>>(),
             name: "memory");
 
+        _diskStorageStrategy = new DiskStorageStrategy(
+            loggerFactory.CreateLogger<DiskStorageStrategy>(),
+            opts.TempDirectory);
+
         _diskCache = new GenericCache<Stream>(
-            new DiskStorageStrategy(loggerFactory.CreateLogger<DiskStorageStrategy>(),
-                opts.TempDirectory),
+            _diskStorageStrategy,
             evictionPolicy,
             opts.DiskCacheSizeBytes,
             timeProvider,
@@ -162,5 +166,14 @@ public sealed class DualTierFileCache : ICache<Stream>
         _memoryCache.Clear();
         _diskCache.Clear();
         _logger.LogInformation("Both cache tiers cleared");
+    }
+
+    /// <summary>
+    /// Deletes the per-process disk cache directory after all entries have been cleared.
+    /// Call after <see cref="Clear"/> on shutdown.
+    /// </summary>
+    public void DeleteCacheDirectory()
+    {
+        _diskStorageStrategy.DeleteCacheDirectory();
     }
 }

--- a/tests/ZipDrive.Infrastructure.Caching.Tests/DualTierFileCacheTests.cs
+++ b/tests/ZipDrive.Infrastructure.Caching.Tests/DualTierFileCacheTests.cs
@@ -163,7 +163,7 @@ public class DualTierFileCacheTests
 
         // Verify temp files exist for disk tier
         var tempFiles = Directory.Exists(options.TempDirectory)
-            ? Directory.GetFiles(options.TempDirectory, "*.zip2vd.cache")
+            ? Directory.GetFiles(options.TempDirectory, "*.zip2vd.cache", SearchOption.AllDirectories)
             : [];
         tempFiles.Should().NotBeEmpty("disk tier should have created temp files");
 
@@ -176,7 +176,7 @@ public class DualTierFileCacheTests
 
         // Temp files should be deleted
         var remainingFiles = Directory.Exists(options.TempDirectory)
-            ? Directory.GetFiles(options.TempDirectory, "*.zip2vd.cache")
+            ? Directory.GetFiles(options.TempDirectory, "*.zip2vd.cache", SearchOption.AllDirectories)
             : [];
         remainingFiles.Should().BeEmpty("Clear() should delete all disk tier temp files");
     }

--- a/tests/ZipDrive.Infrastructure.Caching.Tests/GenericCacheIntegrationTests.cs
+++ b/tests/ZipDrive.Infrastructure.Caching.Tests/GenericCacheIntegrationTests.cs
@@ -395,7 +395,7 @@ public class GenericCacheIntegrationTests : IDisposable
             cache.EntryCount.Should().Be(1);
 
             // Verify temp file was created
-            string[] tempFiles = Directory.GetFiles(_tempDir, "*.zip2vd.cache");
+            string[] tempFiles = Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories);
             tempFiles.Should().HaveCount(1);
         }
         finally
@@ -495,7 +495,7 @@ public class GenericCacheIntegrationTests : IDisposable
             cache.HitRate.Should().Be(0.5);
 
             // Should still have only 1 temp file
-            string[] tempFiles = Directory.GetFiles(_tempDir, "*.zip2vd.cache");
+            string[] tempFiles = Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories);
             tempFiles.Should().HaveCount(1);
         }
         finally
@@ -532,7 +532,7 @@ public class GenericCacheIntegrationTests : IDisposable
             {
             }
 
-            Directory.GetFiles(_tempDir, "*.zip2vd.cache").Should().HaveCount(1);
+            Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories).Should().HaveCount(1);
 
             // Add second entry that fits
             using (ICacheHandle<Stream> handle = await cache.BorrowAsync(
@@ -547,7 +547,7 @@ public class GenericCacheIntegrationTests : IDisposable
             {
             }
 
-            Directory.GetFiles(_tempDir, "*.zip2vd.cache").Should().HaveCount(2);
+            Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories).Should().HaveCount(2);
 
             // Add third entry - should trigger eviction
             using (ICacheHandle<Stream> handle = await cache.BorrowAsync(
@@ -1099,7 +1099,7 @@ public class GenericCacheIntegrationTests : IDisposable
             successCount.Should().Be(100, "All threads should get correct data");
 
             // Only one temp file should exist
-            Directory.GetFiles(_tempDir, "*.zip2vd.cache").Should().HaveCount(1);
+            Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories).Should().HaveCount(1);
         }
         finally
         {
@@ -1397,7 +1397,7 @@ public class GenericCacheIntegrationTests : IDisposable
             cache.BorrowedEntryCount.Should().Be(0);
 
             // Only one temp file should exist
-            Directory.GetFiles(_tempDir, "*.zip2vd.cache").Should().HaveCount(1);
+            Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories).Should().HaveCount(1);
         }
         finally
         {
@@ -1769,7 +1769,7 @@ public class GenericCacheIntegrationTests : IDisposable
                 "All reads must return correct data");
 
             // Should have only 1 temp file at any time
-            int tempFileCount = Directory.GetFiles(_tempDir, "*.zip2vd.cache").Length;
+            int tempFileCount = Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories).Length;
             tempFileCount.Should().BeLessThanOrEqualTo(1,
                 "Temp files should be cleaned up after eviction");
 
@@ -1953,7 +1953,7 @@ public class GenericCacheIntegrationTests : IDisposable
                 "All concurrent disk reads must return correct data");
 
             // Verify no temp file leak
-            int tempFileCount = Directory.GetFiles(_tempDir, "*.zip2vd.cache").Length;
+            int tempFileCount = Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories).Length;
             tempFileCount.Should().BeLessThanOrEqualTo(cacheCapacity,
                 "Should not leak temp files");
         }
@@ -2100,7 +2100,7 @@ public class GenericCacheIntegrationTests : IDisposable
                 using (await AccessKey("disk-evict-A")) { }
 
                 // Verify temp file count
-                int tempFiles = Directory.GetFiles(_tempDir, "*.zip2vd.cache").Length;
+                int tempFiles = Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories).Length;
                 tempFiles.Should().BeLessThanOrEqualTo(3,
                     "Should not accumulate excess temp files");
             }
@@ -2459,7 +2459,7 @@ public class GenericCacheIntegrationTests : IDisposable
                 "Size should not exceed capacity");
 
             // Temp file count should match entry count
-            int tempFileCount = Directory.GetFiles(_tempDir, "*.zip2vd.cache").Length;
+            int tempFileCount = Directory.GetFiles(_tempDir, "*.zip2vd.cache", SearchOption.AllDirectories).Length;
             tempFileCount.Should().Be(entryCount,
                 "Temp file count should match entry count");
         }

--- a/tests/ZipDrive.Infrastructure.Caching.Tests/PerProcessCacheDirectoryTests.cs
+++ b/tests/ZipDrive.Infrastructure.Caching.Tests/PerProcessCacheDirectoryTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace ZipDrive.Infrastructure.Caching.Tests;
+
+public class PerProcessCacheDirectoryTests : IDisposable
+{
+    private readonly string _baseDir;
+    private readonly int _pid = Environment.ProcessId;
+
+    public PerProcessCacheDirectoryTests()
+    {
+        _baseDir = Path.Combine(Path.GetTempPath(), $"zipdrive-perproctest-{Guid.NewGuid():N}");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_baseDir))
+                Directory.Delete(_baseDir, recursive: true);
+        }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void DiskStorageStrategy_CreatesProcessSubdirectory()
+    {
+        var strategy = new DiskStorageStrategy(
+            NullLogger<DiskStorageStrategy>.Instance,
+            _baseDir);
+
+        string expected = Path.Combine(_baseDir, $"ZipDrive-{_pid}");
+        Directory.Exists(expected).Should().BeTrue("the per-process subdirectory should be created");
+    }
+
+    [Fact]
+    public async Task DiskStorageStrategy_StoreAsync_StoresFilesInProcessSubdirectory()
+    {
+        string expectedDir = Path.Combine(_baseDir, $"ZipDrive-{_pid}");
+
+        var strategy = new DiskStorageStrategy(
+            NullLogger<DiskStorageStrategy>.Instance,
+            _baseDir);
+
+        byte[] data = new byte[1024];
+        Random.Shared.NextBytes(data);
+        var result = new CacheFactoryResult<Stream>
+        {
+            Value = new MemoryStream(data),
+            SizeBytes = data.Length
+        };
+
+        var stored = await strategy.StoreAsync(result, CancellationToken.None);
+
+        var files = Directory.GetFiles(expectedDir, "*.zip2vd.cache");
+        files.Should().HaveCount(1, "cache file should be stored in the process subdirectory");
+
+        // Cleanup
+        strategy.Dispose(stored);
+    }
+
+    [Fact]
+    public void DiskStorageStrategy_DeleteCacheDirectory_RemovesEntireDirectory()
+    {
+        string expectedDir = Path.Combine(_baseDir, $"ZipDrive-{_pid}");
+
+        var strategy = new DiskStorageStrategy(
+            NullLogger<DiskStorageStrategy>.Instance,
+            _baseDir);
+
+        // Create a dummy file in the directory to simulate cache content
+        File.WriteAllText(Path.Combine(expectedDir, "dummy.zip2vd.cache"), "test");
+        Directory.Exists(expectedDir).Should().BeTrue();
+
+        strategy.DeleteCacheDirectory();
+
+        Directory.Exists(expectedDir).Should().BeFalse("the entire subdirectory should be deleted");
+        Directory.Exists(_baseDir).Should().BeTrue("the base directory should NOT be deleted");
+    }
+
+    [Fact]
+    public void DualTierFileCache_ConstructsCorrectSubdirectoryName()
+    {
+        var cacheOpts = Microsoft.Extensions.Options.Options.Create(new CacheOptions
+        {
+            MemoryCacheSizeMb = 10,
+            DiskCacheSizeMb = 10,
+            TempDirectory = _baseDir
+        });
+
+        var cache = new DualTierFileCache(
+            cacheOpts,
+            new LruEvictionPolicy(),
+            TimeProvider.System,
+            NullLogger<DualTierFileCache>.Instance,
+            NullLoggerFactory.Instance);
+
+        var dirs = Directory.GetDirectories(_baseDir);
+        dirs.Should().HaveCount(1);
+        Path.GetFileName(dirs[0]).Should().Be($"ZipDrive-{_pid}");
+    }
+
+    [Fact]
+    public void DualTierFileCache_DeleteCacheDirectory_RemovesDirectory()
+    {
+        var cacheOpts = Microsoft.Extensions.Options.Options.Create(new CacheOptions
+        {
+            MemoryCacheSizeMb = 10,
+            DiskCacheSizeMb = 10,
+            TempDirectory = _baseDir
+        });
+
+        var cache = new DualTierFileCache(
+            cacheOpts,
+            new LruEvictionPolicy(),
+            TimeProvider.System,
+            NullLogger<DualTierFileCache>.Instance,
+            NullLoggerFactory.Instance);
+
+        var dirs = Directory.GetDirectories(_baseDir);
+        dirs.Should().HaveCount(1);
+
+        cache.Clear();
+        cache.DeleteCacheDirectory();
+
+        Directory.GetDirectories(_baseDir).Should().BeEmpty(
+            "DeleteCacheDirectory should remove the per-process subdirectory");
+    }
+
+    [Fact]
+    public void DiskStorageStrategy_NullTempDirectory_CreatesSubdirectoryUnderSystemTemp()
+    {
+        var strategy = new DiskStorageStrategy(
+            NullLogger<DiskStorageStrategy>.Instance,
+            tempDirectory: null);
+
+        string expected = Path.Combine(Path.GetTempPath(), $"ZipDrive-{_pid}");
+        try
+        {
+            Directory.Exists(expected).Should().BeTrue(
+                "the per-process subdirectory should be created under the system temp directory");
+        }
+        finally
+        {
+            strategy.DeleteCacheDirectory();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `DiskStorageStrategy` now always creates a `ZipDrive-{pid}` subdirectory under the configured `TempDirectory`, isolating disk cache files between concurrent ZipDrive processes
- `DeleteCacheDirectory()` cleans up the per-process subdirectory on graceful shutdown (called by `CacheMaintenanceService` after `Clear()`)
- `DualTierFileCache` simplified — no longer needs `IOptions<MountSettings>` since `DiskStorageStrategy` owns its directory naming
- Added `appsettings.dev.jsonc` as an optional gitignored config override for local development
- 6 new tests covering subdirectory creation, file storage, cleanup, DualTierFileCache integration, and null-tempDirectory fallback

## Test plan

- [x] All 249 tests pass (33 + 72 + 73 + 70 + 1)
- [x] New `PerProcessCacheDirectoryTests` (6 tests) cover subdirectory lifecycle
- [x] Existing disk cache tests updated with `SearchOption.AllDirectories`
- [x] Endurance test passes (~72s soak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)