### PR TITLE
docs: sync documentation with strategy-owned materialization refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **ZipDrive** is a clean-architecture rewrite of the ZipDrive virtual file system. It mounts ZIP archives (and potentially other formats like TAR, 7Z) as accessible Windows drives using DokanNet. The project has the **core caching layer and streaming ZIP reader implemented and tested**.
 
-**Current Status**: Core caching layer (66 tests), streaming ZIP reader (15 tests), dual-tier cache coordinator, OpenTelemetry observability, DokanNet adapter, background cache maintenance, and automatic charset detection for non-UTF8 filenames implemented. 242 total tests passing. 8-hour soak test validated.
+**Current Status**: Core caching layer (66 tests), streaming ZIP reader (15 tests), file content cache with strategy-owned materialization, OpenTelemetry observability, DokanNet adapter, background cache maintenance, and automatic charset detection for non-UTF8 filenames implemented. 259 total tests passing. 8-hour soak test validated.
 
 ## Development Workflow Requirements
 
@@ -196,7 +196,7 @@ This is the **most important** subsystem. It solves the core problem: ZIP provid
 
 **Architecture**: Generic cache with pluggable storage strategies, borrow/return pattern, and dual-tier routing
 - **GenericCache<T>**: Single cache implementation with reference counting and `System.Diagnostics.Metrics` instrumentation
-- **DualTierFileCache**: Routes to memory or disk tier based on `CacheOptions.SmallFileCutoffMb` (default 50MB)
+- **FileContentCache**: Owns ZIP extraction, tier routing, and caching. Routes to memory or disk tier based on `CacheOptions.SmallFileCutoffMb` (default 50MB)
 - **MemoryStorageStrategy**: `byte[]` storage for small files (< 50MB)
 - **DiskStorageStrategy**: `MemoryMappedFile` backed by temp files for large files (≥ 50MB)
 - **ObjectStorageStrategy<T>**: Direct object storage for metadata caching
@@ -335,7 +335,7 @@ DokanNet integration for Windows file system mounting.
 Command-line interface entry point with OpenTelemetry SDK wiring.
 
 **Key Responsibilities**:
-- DI registration for all services (including `DualTierFileCache`)
+- DI registration for all services (including `FileContentCache`)
 - OpenTelemetry SDK configuration (opt-in; OTLP export to Aspire Dashboard when endpoint configured)
 - Serilog structured logging
 - Configuration binding (`Mount`, `Cache`, `OpenTelemetry` sections)
@@ -346,10 +346,11 @@ Command-line interface entry point with OpenTelemetry SDK wiring.
 |---------|----------|---------|
 | **Clean Architecture** | Solution structure | Dependency inversion, testability |
 | **Pluggable Strategy** | `IStorageStrategy<T>`, `IEvictionPolicy` | Storage and eviction extensibility |
+| **Strategy-Owned Materialization** | `IStorageStrategy.MaterializeAsync()` | Strategy calls factory, consumes stream, disposes resources — eliminates intermediate buffering |
 | **Borrow/Return (RAII)** | `GenericCache<T>`, `ICacheHandle<T>` | Reference counting, eviction protection |
 | **Lazy Materialization** | `Lazy<Task<T>>` | Thundering herd prevention |
 | **Async Cleanup** | `DiskStorageStrategy` | Non-blocking eviction |
-| **Dual-Tier Routing** | `DualTierFileCache` | Size-based memory/disk routing |
+| **Dual-Tier Routing** | `FileContentCache` | Size-based memory/disk routing |
 | **Static Telemetry** | `CacheTelemetry`, `ZipTelemetry`, `DokanTelemetry` | Zero-DI metrics/tracing |
 | **Object Pooling** | Archive sessions (future) | Reuse expensive resources |
 | **Bytes-First Decoding** | `ZipCentralDirectoryEntry.FileNameBytes` | Defer string decode until encoding is known |
@@ -537,7 +538,7 @@ Refer to [`IMPLEMENTATION_CHECKLIST.md`](src/Docs/IMPLEMENTATION_CHECKLIST.md) f
 | Phase 3 (Storage) | ✅ Complete | `MemoryStorageStrategy`, `DiskStorageStrategy`, `ObjectStorageStrategy<T>` |
 | Phase 4 (Eviction) | ✅ Complete | `LruEvictionPolicy` |
 | Phase 5 (Tests) | ✅ Complete | 42 integration tests passing |
-| Phase 6 (Coordinator) | ✅ Complete | `DualTierFileCache` with size-hint routing (6 tests) |
+| Phase 6 (Coordinator) | ✅ Complete | `FileContentCache` with strategy-owned materialization and size-hint routing (6 tests) |
 | Phase 7 (Observability) | ✅ Complete | OpenTelemetry metrics, tracing, Aspire Dashboard export |
 
 ### Streaming ZIP Reader
@@ -557,10 +558,10 @@ Refer to [`IMPLEMENTATION_CHECKLIST.md`](src/Docs/IMPLEMENTATION_CHECKLIST.md) f
 |-----------|--------|-------------|
 | ZipArchiveProvider | ⏳ Pending | `IArchiveProvider` implementation |
 | DokanNet Adapter | ✅ Complete | `DokanFileSystemAdapter` + `DokanHostedService` |
-| CLI | ✅ Complete | OTel wiring, DualTierFileCache DI, config binding, single-file publish |
+| CLI | ✅ Complete | OTel wiring, FileContentCache DI, config binding, single-file publish |
 | Multi-archive | ✅ Complete | `ArchiveTrie` + `ArchiveDiscovery` |
 | Observability | ✅ Complete | OpenTelemetry metrics/tracing, Aspire Dashboard |
-| Dual-tier Cache | ✅ Complete | `DualTierFileCache` with size-hint routing |
+| Dual-tier Cache | ✅ Complete | `FileContentCache` with strategy-owned materialization and size-hint routing |
 | Cache Maintenance | ✅ Complete | `CacheMaintenanceService` background eviction + cleanup |
 | Endurance Testing | ✅ Complete | 8-hour soak test with SHA-256 verification, 23 concurrent tasks |
 | Charset Detection | ✅ Complete | Automatic encoding detection for non-UTF8 ZIP filenames (Shift-JIS, GBK, EUC-KR, etc.) |
@@ -621,7 +622,7 @@ ZipDrive is considered complete when:
 - [x] ZIP reader implemented and tested (33 tests, including encoding detection)
 - [x] DokanNet adapter functional (mount/unmount works)
 - [x] CLI accepts arguments and mounts drives
-- [x] Dual-tier cache coordinator implemented and tested (6 tests)
+- [x] Dual-tier cache coordinator with strategy-owned materialization (6 tests)
 - [x] OpenTelemetry observability (metrics, tracing, Aspire Dashboard)
 - [x] Background cache maintenance with configurable interval
 - [ ] All performance targets met

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ dotnet test tests/ZipDrive.EnduranceTests
 ENDURANCE_DURATION_HOURS=8 dotnet test tests/ZipDrive.EnduranceTests
 ```
 
-**Test coverage**: 242 tests across unit, integration, concurrency, and endurance suites. 8-hour soak test validated with zero errors and zero handle leaks.
+**Test coverage**: 259 tests across unit, integration, concurrency, and endurance suites. 8-hour soak test validated with zero errors and zero handle leaks.
 
 ## Design Documents
 

--- a/src/Docs/CACHING_DESIGN.md
+++ b/src/Docs/CACHING_DESIGN.md
@@ -1,8 +1,8 @@
 # ZipDrive - File Content Cache Design Document
 
-**Version:** 2.0
-**Last Updated:** 2026-02-23
-**Status:** ✅ Implementation Complete (Core + Dual-Tier + Observability)
+**Version:** 3.0
+**Last Updated:** 2026-02-27
+**Status:** ✅ Implementation Complete (Core + Strategy-Owned Materialization + Dual-Tier + Observability)
 
 ---
 
@@ -12,7 +12,7 @@
 
 **The Solution**: Dual-tier caching that materializes (fully decompresses) ZIP entries into random-access storage with TTL-based expiration and capacity limits.
 
-**API Design**: Generic `ICache<T>` interface where the factory returns `CacheFactoryResult<T>` containing both the value and metadata (including size). This design allows the factory to discover the size during data preparation, rather than requiring the caller to know it upfront.
+**API Design**: Generic `ICache<T>` interface where the factory returns `CacheFactoryResult<T>` containing both the value and metadata (including size). `CacheFactoryResult<T>` implements `IAsyncDisposable` with an `OnDisposed` callback, enabling chained resource cleanup. Strategies own the full materialization pipeline via `MaterializeAsync()` — they call the factory, consume the stream, and dispose resources, eliminating intermediate buffering.
 
 **Unified Architecture**: A single `GenericCache<TStored, TValue>` implementation handles all caching concerns (TTL, eviction, capacity, concurrency). Storage differences are abstracted via `IStorageStrategy`:
 - `MemoryStorageStrategy` → byte[] for small files
@@ -314,15 +314,12 @@ User perspective:
    │  └─ If yes: Wait for same Lazy<Task<T>>, share result
    └─ If no: This thread will materialize
    ↓
-8. GenericCache: Call factory to get CacheFactoryResult
-   ├─ Factory extracts file from ZIP
-   └─ Factory returns: { Value=stream, SizeBytes=80MB, Metadata=... }
+8. GenericCache: Delegate to IStorageStrategy.MaterializeAsync(factory)
+   ├─ Strategy calls factory internally to get CacheFactoryResult
+   ├─ Strategy consumes stream (e.g., DiskStrategy pipes ZIP → temp file)
+   └─ Strategy disposes factory resources via CacheFactoryResult.DisposeAsync()
    ↓
-9. GenericCache: Call IStorageStrategy.StoreAsync(factoryResult)
-   ├─ DiskStorageStrategy internally: Create temp file /tmp/{guid}.zip2vd
-   ├─ DiskStorageStrategy internally: Write 80MB to temp file
-   ├─ DiskStorageStrategy internally: Create MemoryMappedFile from temp file
-   └─ DiskStorageStrategy internally: Return StoredEntry (wraps MMF + path)
+9. Strategy returns StoredEntry (opaque, wraps MMF + path or byte[])
    ↓
 10. GenericCache: Store entry in ConcurrentDictionary
     └─ _cache[key] = new CacheEntry(storedEntry, RefCount=0, ...)
@@ -449,9 +446,11 @@ namespace ZipDrive.Infrastructure.Caching;
 /// <summary>
 /// Result from cache factory, containing the cached value and metadata.
 /// The factory is responsible for preparing the data and reporting its size.
+/// Implements IAsyncDisposable to allow storage strategies to dispose the
+/// value and chain resource cleanup via OnDisposed.
 /// </summary>
 /// <typeparam name="T">Type of cached value</typeparam>
-public sealed class CacheFactoryResult<T>
+public sealed class CacheFactoryResult<T> : IAsyncDisposable
 {
     /// <summary>The cached value to store.</summary>
     public required T Value { get; init; }
@@ -466,6 +465,23 @@ public sealed class CacheFactoryResult<T>
     /// Optional metadata (e.g., content type, compression ratio, original filename).
     /// </summary>
     public IReadOnlyDictionary<string, object>? Metadata { get; init; }
+
+    /// <summary>
+    /// Optional callback invoked after Value is disposed.
+    /// Use to chain cleanup of owning resources (e.g., dispose an IZipReader
+    /// after the decompressed stream has been consumed by the storage strategy).
+    /// </summary>
+    public Func<ValueTask>? OnDisposed { get; init; }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Value is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync();
+        else if (Value is IDisposable disposable)
+            disposable.Dispose();
+        if (OnDisposed is not null)
+            await OnDisposed();
+    }
 }
 
 /// <summary>
@@ -538,13 +554,19 @@ public interface ICache<T>
 }
 
 /// <summary>
-/// File cache abstraction for materialized ZIP entries.
+/// File content cache abstraction for materialized ZIP entries.
+/// Owns ZIP extraction, tier routing, and caching.
 /// Converts sequential ZIP streams into random-access streams.
 /// </summary>
-public interface IFileCache : ICache<Stream>
+public interface IFileContentCache
 {
-    // Inherits all members from ICache<Stream>
-    // Can add file-specific members if needed in the future
+    Task<ICacheHandle<Stream>> GetOrExtractAsync(
+        string archiveKey,
+        ZipEntryInfo entryInfo,
+        string archivePath,
+        TimeSpan ttl,
+        CancellationToken cancellationToken = default);
+    // Also exposes EvictExpired(), ProcessPendingCleanup(), Clear(), etc.
 }
 ```
 
@@ -583,13 +605,16 @@ public sealed class StoredEntry
 public interface IStorageStrategy<TValue>
 {
     /// <summary>
-    /// Stores the factory result and returns an opaque StoredEntry.
-    /// The actual storage format (byte[], MMF, object) is implementation-specific.
+    /// Calls the factory delegate, consumes the result, disposes factory resources,
+    /// and returns an opaque StoredEntry. The strategy owns the full materialization
+    /// pipeline — this enables direct streaming (e.g., ZIP → disk) without intermediate buffering.
     /// </summary>
-    /// <param name="result">The factory result containing value and size</param>
+    /// <param name="factory">Factory delegate that produces the value to cache</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Opaque stored entry wrapping the internal representation</returns>
-    Task<StoredEntry> StoreAsync(CacheFactoryResult<TValue> result, CancellationToken cancellationToken);
+    Task<StoredEntry> MaterializeAsync(
+        Func<CancellationToken, Task<CacheFactoryResult<TValue>>> factory,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves the value from the stored entry.
@@ -628,8 +653,11 @@ public interface IStorageStrategy<TValue>
 /// </summary>
 public sealed class MemoryStorageStrategy : IStorageStrategy<Stream>
 {
-    public async Task<StoredEntry> StoreAsync(CacheFactoryResult<Stream> result, CancellationToken ct)
+    public async Task<StoredEntry> MaterializeAsync(
+        Func<CancellationToken, Task<CacheFactoryResult<Stream>>> factory,
+        CancellationToken ct)
     {
+        await using var result = await factory(ct);
         using var ms = new MemoryStream((int)result.SizeBytes);
         await result.Value.CopyToAsync(ms, ct);
         var bytes = ms.ToArray();
@@ -669,15 +697,21 @@ public sealed class DiskStorageStrategy : IStorageStrategy<Stream>
         _tempDirectory = tempDirectory;
     }
 
-    public async Task<StoredEntry> StoreAsync(CacheFactoryResult<Stream> result, CancellationToken ct)
+    public async Task<StoredEntry> MaterializeAsync(
+        Func<CancellationToken, Task<CacheFactoryResult<Stream>>> factory,
+        CancellationToken ct)
     {
         var tempPath = Path.Combine(_tempDirectory, $"{Guid.NewGuid()}.cache");
 
-        // Write to temp file
-        await using var fileStream = new FileStream(tempPath, FileMode.Create,
-            FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous);
-        await result.Value.CopyToAsync(fileStream, ct);
-        await fileStream.FlushAsync(ct);
+        // Call factory and pipe directly to temp file — no intermediate buffer
+        await using (var result = await factory(ct))
+        {
+            await using var fileStream = new FileStream(tempPath, FileMode.Create,
+                FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous);
+            await result.Value.CopyToAsync(fileStream, ct);
+            await fileStream.FlushAsync(ct);
+        }
+        // Factory result (and its Value stream + OnDisposed callback) are now disposed
 
         // Create memory-mapped file for random access
         var mmf = MemoryMappedFile.CreateFromFile(tempPath, FileMode.Open,
@@ -721,9 +755,12 @@ internal sealed record DiskCacheEntry(string TempFilePath, MemoryMappedFile Memo
 /// </summary>
 public sealed class ObjectStorageStrategy<T> : IStorageStrategy<T>
 {
-    public Task<StoredEntry> StoreAsync(CacheFactoryResult<T> result, CancellationToken ct)
+    public async Task<StoredEntry> MaterializeAsync(
+        Func<CancellationToken, Task<CacheFactoryResult<T>>> factory,
+        CancellationToken ct)
     {
-        return Task.FromResult(new StoredEntry(result.Value!, result.SizeBytes));
+        await using var result = await factory(ct);
+        return new StoredEntry(result.Value!, result.SizeBytes);
     }
 
     public T Retrieve(StoredEntry stored)
@@ -838,17 +875,8 @@ public sealed class GenericCache<T> : ICache<T>
         Func<CancellationToken, Task<CacheFactoryResult<T>>> factory,
         CancellationToken cancellationToken)
     {
-        // Call factory to get data AND size
-        var result = await factory(cancellationToken);
-
-        // ═══════════════════════════════════════════════════════════
-        // LAYER 3: Eviction (only if capacity exceeded)
-        // Only evicts entries with RefCount = 0
-        // ═══════════════════════════════════════════════════════════
-        await EvictIfNeededAsync(result.SizeBytes);
-
-        // Store using strategy - returns opaque StoredEntry
-        var stored = await _storageStrategy.StoreAsync(result, cancellationToken);
+        // Strategy owns the full pipeline: call factory → consume stream → dispose resources → return StoredEntry
+        var stored = await _storageStrategy.MaterializeAsync(factory, cancellationToken);
 
         var entry = new CacheEntry(
             cacheKey, stored,

--- a/src/Docs/IMPLEMENTATION_CHECKLIST.md
+++ b/src/Docs/IMPLEMENTATION_CHECKLIST.md
@@ -235,7 +235,7 @@ The caching layer uses a **generic cache with pluggable storage strategies**:
 
 ## Phase 6: Dual-Tier Coordinator ✅ COMPLETE
 
-### 6.1 DualTierFileCache Class
+### 6.1 FileContentCache Class
 
 - [x] Constructor: Create both memory and disk GenericCache instances with named tiers
 - [x] Route based on file size via `BorrowAsync(key, ttl, sizeHintBytes, factory)` overload
@@ -247,7 +247,7 @@ The caching layer uses a **generic cache with pluggable storage strategies**:
 ### 6.2 VFS Integration
 
 - [x] `ZipVirtualFileSystem.ReadFileAsync` passes size hint from `ZipEntryInfo.UncompressedSize`
-- [x] DI registration in `Program.cs` replaces single `GenericCache<Stream>` with `DualTierFileCache`
+- [x] DI registration in `Program.cs` replaces single `GenericCache<Stream>` with `FileContentCache`
 
 **Phase 6 Checkpoint:** ✅ Dual-tier cache coordinator implemented and tested
 
@@ -465,6 +465,6 @@ The streaming ZIP reader provides memory-efficient parsing of ZIP archives:
 
 1. ⏳ Implement `ZipArchiveProvider` (IArchiveProvider implementation)
 2. ✅ Implement DokanNet file system adapter — Complete (`DokanFileSystemAdapter` + `DokanHostedService`)
-3. ✅ Create dual-tier cache coordinator — Complete (`DualTierFileCache` with size-hint routing)
+3. ✅ Create file content cache — Complete (`FileContentCache` with strategy-owned materialization and size-hint routing)
 4. ⏳ Add performance benchmarks
 5. ✅ Add observability/metrics — Complete (OpenTelemetry metrics, tracing, Aspire Dashboard)


### PR DESCRIPTION
## Summary
- Updated `DualTierFileCache` → `FileContentCache` across CLAUDE.md, CACHING_DESIGN.md, IMPLEMENTATION_CHECKLIST.md
- Updated `IStorageStrategy.StoreAsync` → `MaterializeAsync` with strategy-owned pipeline in CACHING_DESIGN.md
- Updated `CacheFactoryResult<T>` to reflect `IAsyncDisposable` with `OnDisposed` callback in CACHING_DESIGN.md
- Updated `IFileCache` → `IFileContentCache` in CACHING_DESIGN.md
- Updated test count from 242 → 259 in CLAUDE.md and README.md
- Added Strategy-Owned Materialization pattern to CLAUDE.md design patterns table

## Test plan
- [x] Verify no stale references to `DualTierFileCache`, `IFileCache`, or `StoreAsync` remain in docs
- [x] Confirm documentation-only change — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)